### PR TITLE
fix for nginx deployment spec

### DIFF
--- a/kubernetes/example-nginx-deployment.yaml
+++ b/kubernetes/example-nginx-deployment.yaml
@@ -43,11 +43,16 @@ data:
     }
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx
+  labels:
+    app: nginx
 spec:
+  selector:
+    matchLabels:
+      app: nginx
   replicas: 2
   template:
     metadata:

--- a/kubernetes/sensu-backend-statefulset.yaml
+++ b/kubernetes/sensu-backend-statefulset.yaml
@@ -79,18 +79,18 @@ spec:
           subPath: sensu-ca-cert
         resources:
           requests:
+            memory: 1024M
+            cpu: 0.3
+          limits:
             memory: 2048M
             cpu: 1.0
-          limits:
-            memory: 4096M
-            cpu: 2.0
 
       - name: sensu-agent
         image: sensu/sensu:5.16.1
         command: ["/opt/sensu/bin/sensu-agent", "start", "--log-level=debug", "--insecure-skip-tls-verify"]
         env:
         - name: SENSU_BACKEND_URL
-          value: wss://sensu-backend-0.sensu.sensu-system.svc.cluster.local:8081 wss://sensu-backend-1.sensu.sensu-system.svc.cluster.local:8081 wss://sensu-backend-2.sensu.sensu-system.svc.cluster.local:8081
+          value: ws://sensu-backend-0.sensu.sensu-system.svc.cluster.local:8081 ws://sensu-backend-1.sensu.sensu-system.svc.cluster.local:8081 ws://sensu-backend-2.sensu.sensu-system.svc.cluster.local:8081
         - name: SENSU_NAMESPACE
           value: sensu-system
         - name: SENSU_SUBSCRIPTIONS

--- a/kubernetes/sensu-backend-statefulset.yaml
+++ b/kubernetes/sensu-backend-statefulset.yaml
@@ -39,7 +39,7 @@ spec:
       - name: sensu-backend
         image: sensu/sensu:5.16.1
         command: [
-          "/opt/sensu/bin/sensu-backend", "start",
+          "sensu-backend", "start",
           "--log-level=debug",
           "--cache-dir=/var/cache/sensu/sensu-backend",
           "--state-dir=/var/lib/sensu",

--- a/sensu/check-nginx.yaml
+++ b/sensu/check-nginx.yaml
@@ -4,7 +4,7 @@ api_version: core/v2
 metadata:
   name: check-nginx
 spec:
-  command: check_http -H 127.0.0.1 -u / -P 80 -N
+  command: check_http -H 127.0.0.1 -u / -p 80 -N
   runtime_assets:
   - sensu/monitoring-plugins
   publish: true


### PR DESCRIPTION
fix for nginx deployment spec to address errors when running against latest minikube using k8s 1.17

1. change spec to use app/v1 as extensions/v1beta1 was removed

2. Add label selector template for pod template section

3. Fix sensu-agent sidecar config in sensu-backend statefulset

4. Adjust requested CPU down a bit to make this work on minikube a bit more easily