### PR TITLE
Minikube fix

### DIFF
--- a/Dockerfile.el6
+++ b/Dockerfile.el6
@@ -2,7 +2,7 @@
 # See https://sensu.io/downloads for available downloads/installers 
 
 FROM centos:6
-ARG SENSU_VERSION=6.2.5
+ARG SENSU_VERSION=6.7.2
 ARG SENSU_PLATFORM=linux
 ARG SENSU_ARCH=amd64
 RUN \

--- a/Dockerfile.el6
+++ b/Dockerfile.el6
@@ -2,7 +2,7 @@
 # See https://sensu.io/downloads for available downloads/installers 
 
 FROM centos:6
-ARG SENSU_VERSION=6.7.2
+ARG SENSU_VERSION=6.12.0
 ARG SENSU_PLATFORM=linux
 ARG SENSU_ARCH=amd64
 RUN \

--- a/Dockerfile.el7
+++ b/Dockerfile.el7
@@ -2,7 +2,7 @@
 # See https://sensu.io/downloads for available downloads/installers
 
 FROM centos:7
-ARG SENSU_VERSION=6.2.5
+ARG SENSU_VERSION=6.7.2
 ARG SENSU_PLATFORM=linux
 ARG SENSU_ARCH=amd64
 RUN \

--- a/Dockerfile.el7
+++ b/Dockerfile.el7
@@ -2,7 +2,7 @@
 # See https://sensu.io/downloads for available downloads/installers
 
 FROM centos:7
-ARG SENSU_VERSION=6.7.2
+ARG SENSU_VERSION=6.12.0
 ARG SENSU_PLATFORM=linux
 ARG SENSU_ARCH=amd64
 RUN \

--- a/kubernetes/example-nginx-deployment.yaml
+++ b/kubernetes/example-nginx-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           subPath: nginx.conf
 
       - name: sensu-agent
-        image: sensu/sensu:6.2.5
+        image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--detect-cloud-provider", "true",

--- a/kubernetes/example-nginx-deployment.yaml
+++ b/kubernetes/example-nginx-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           subPath: nginx.conf
 
       - name: sensu-agent
-        image: sensu/sensu:6.7.2
+        image: sensu/sensu:6.12.0
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--detect-cloud-provider", "true",

--- a/kubernetes/sensu-backend.yaml
+++ b/kubernetes/sensu-backend.yaml
@@ -242,9 +242,6 @@ spec:
           "--log-level", "debug",
           "--debug", "true",
           "--no-embed-etcd",
-          "--api-listen-address", "0.0.0.0:8080",
-          "--agent-host", "0.0.0.0",
-          "--dashboard-host", "0.0.0.0",
           "--etcd-client-urls", "http://sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379",
           "--etcd-name", "sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local",
         ]

--- a/kubernetes/sensu-backend.yaml
+++ b/kubernetes/sensu-backend.yaml
@@ -278,7 +278,7 @@ spec:
             - wget
             - -q
             - -O-
-            - http://localhost:8080/health
+            - http://127.0.0.1:8080/health
 
       - name: sensu-agent
         image: sensu/sensu:6.7.2

--- a/kubernetes/sensu-backend.yaml
+++ b/kubernetes/sensu-backend.yaml
@@ -100,6 +100,7 @@ spec:
           "--initial-cluster-state", "new",
           "--name", "$(ETCD_NAME)",
           "--listen-client-urls", "http://0.0.0.0:2379",
+          "--election-timeout=50000",
           "--advertise-client-urls", "http://$(ETCD_NAME):2379",
         ]
         env:
@@ -206,24 +207,11 @@ spec:
           optional: true
       initContainers:
       - name: wait-for-etcd
-        image: busybox:latest
-        command: [
-          "sh",
-          "-c",
-          "until nslookup sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local; do echo waiting for sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local; sleep 2; done",
-        ]
-        env:
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      initContainers:
-      - name: wait-for-etcd
         image: tutum/dnsutils:latest
         command: [
           "/bin/sh",
           "-c",
-          "export READY=1 && while [ $READY -gt 0 ]; do host $(TARGET_DNS); READY=$?; sleep 2; done;",
+          "export READY=1 && while [ $READY -gt 0 ]; do host ${TARGET_DNS}; READY=$?; sleep 2; done && sleep 10",
         ]
         env:
         - name: KUBE_NAMESPACE
@@ -343,11 +331,30 @@ spec:
   template:
     spec:
       activeDeadlineSeconds: 60
+      initContainers:
+      - name: wait-for-etcd
+        image: tutum/dnsutils:latest
+        command: [
+          "/bin/sh",
+          "-c",
+          "export READY=1 && while [ $READY -gt 0 ]; do host ${TARGET_DNS}; READY=$?; sleep 2; done && sleep 10",
+        ]
+        env:
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: TARGET_DNS
+          value: "sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local"
+        ports: []
+        volumeMounts: []
       containers:
       - name: sensu-backend-init
         image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-backend", "init",
+          "--wait",
+          "--timeout", "120s",
           "--etcd-client-urls", "http://sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379",
           #"/bin/sh",
           #"-c",

--- a/kubernetes/sensu-backend.yaml
+++ b/kubernetes/sensu-backend.yaml
@@ -138,7 +138,7 @@ spec:
             - http://127.0.0.1:2379/health
 
       - name: sensu-agent
-        image: sensu/sensu:6.2.5
+        image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--log-level", "warn",
@@ -236,12 +236,15 @@ spec:
         volumeMounts: []
       containers:
       - name: sensu-backend
-        image: sensu/sensu:6.2.5
+        image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-backend", "start",
           "--log-level", "debug",
           "--debug", "true",
           "--no-embed-etcd",
+          "--api-listen-address", "0.0.0.0:8080",
+          "--agent-host", "0.0.0.0",
+          "--dashboard-host", "0.0.0.0",
           "--etcd-client-urls", "http://sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379",
           "--etcd-name", "sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local",
         ]
@@ -270,18 +273,18 @@ spec:
             memory: 4096M
             cpu: 2.0
         readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 20
           exec:
             command:
             - wget
-            - --no-check-certificate
             - -q
             - -O-
-            - http://127.0.0.1:8080/health
+            - http://localhost:8080/health
 
       - name: sensu-agent
-        image: sensu/sensu:6.2.5
+        image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--detect-cloud-provider", "true",
@@ -338,19 +341,20 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  backoffLimit: 5
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       activeDeadlineSeconds: 60
       containers:
       - name: sensu-backend-init
-        image: sensu/sensu:6.2.5
+        image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-backend", "init",
           "--etcd-client-urls", "http://sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379",
-          # "/bin/sh",
-          # "-c",
-          # "sleep 30 && sensu-backend init --etcd-client-urls=http://sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379",
+          #"/bin/sh",
+          #"-c",
+          #'sleep 30 && sensu-backend init --etcd-client-urls=http://sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379',
         ]
         env:
         - name: KUBE_NAMESPACE

--- a/kubernetes/sensu-backend.yaml
+++ b/kubernetes/sensu-backend.yaml
@@ -101,7 +101,7 @@ spec:
           "--name", "$(ETCD_NAME)",
           "--listen-client-urls", "http://0.0.0.0:2379",
           "--election-timeout=50000",
-          "--advertise-client-urls", "http://$(ETCD_NAME):2379",
+          "--advertise-client-urls", "http://$(ETCD_NAME).sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local:2379",
         ]
         env:
         - name: KUBE_NAMESPACE
@@ -128,18 +128,14 @@ spec:
             memory: 4096M
             cpu: 2.0
         readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          exec:
-            command:
-            - wget
-            - --no-check-certificate
-            - -q
-            - -O-
-            - http://127.0.0.1:2379/health
-
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 20
+          httpGet:
+            path: /health
+            port: 2379
       - name: sensu-agent
-        image: sensu/sensu:6.7.2
+        image: sensu/sensu:6.12.0
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--log-level", "warn",
@@ -207,11 +203,11 @@ spec:
           optional: true
       initContainers:
       - name: wait-for-etcd
-        image: tutum/dnsutils:latest
+        image: busybox:latest
         command: [
           "/bin/sh",
           "-c",
-          "export READY=1 && while [ $READY -gt 0 ]; do host ${TARGET_DNS}; READY=$?; sleep 2; done && sleep 10",
+          "until nslookup sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local; do echo waiting for sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local; sleep 2; done",
         ]
         env:
         - name: KUBE_NAMESPACE
@@ -224,7 +220,7 @@ spec:
         volumeMounts: []
       containers:
       - name: sensu-backend
-        image: sensu/sensu:6.7.2
+        image: sensu/sensu:6.12.0
         command: [
           "/opt/sensu/bin/sensu-backend", "start",
           "--log-level", "debug",
@@ -261,15 +257,11 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 30
           timeoutSeconds: 20
-          exec:
-            command:
-            - wget
-            - -q
-            - -O-
-            - http://127.0.0.1:8080/health
-
+          httpGet:
+            path: /health
+            port: 8080
       - name: sensu-agent
-        image: sensu/sensu:6.7.2
+        image: sensu/sensu:6.12.0
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--detect-cloud-provider", "true",
@@ -333,11 +325,11 @@ spec:
       activeDeadlineSeconds: 60
       initContainers:
       - name: wait-for-etcd
-        image: tutum/dnsutils:latest
+        image: busybox:latest
         command: [
           "/bin/sh",
           "-c",
-          "export READY=1 && while [ $READY -gt 0 ]; do host ${TARGET_DNS}; READY=$?; sleep 2; done && sleep 10",
+          "until nslookup sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local; do echo waiting for sensu-etcd-0.sensu-etcd.$(KUBE_NAMESPACE).svc.cluster.local; sleep 2; done",
         ]
         env:
         - name: KUBE_NAMESPACE
@@ -350,7 +342,7 @@ spec:
         volumeMounts: []
       containers:
       - name: sensu-backend-init
-        image: sensu/sensu:6.7.2
+        image: sensu/sensu:6.12.0
         command: [
           "/opt/sensu/bin/sensu-backend", "init",
           "--wait",

--- a/kubernetes/sensu-daemonset.yaml
+++ b/kubernetes/sensu-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       volumes: []
       containers:
       - name: sensu-agent
-        image: sensu/sensu:6.2.5
+        image: sensu/sensu:6.7.2
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--detect-cloud-provider", "true",

--- a/kubernetes/sensu-daemonset.yaml
+++ b/kubernetes/sensu-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       volumes: []
       containers:
       - name: sensu-agent
-        image: sensu/sensu:6.7.2
+        image: sensu/sensu:6.12.0
         command: [
           "/opt/sensu/bin/sensu-agent", "start",
           "--detect-cloud-provider", "true",


### PR DESCRIPTION
This is the extended fixes to the PR: #10 

New Changes:
- Updated to latest sensu version 6.12.0
- Updated ETCD_ADVERTISE_CLIENT_URLS to use the correct pod IPs
- Replaced tatum/dnsutil with busybox for better compatibility

Prev Changes:

- Update to latest sensu release 6.7.2
- fix sensu-backend readinessProbe settings to work with minikube
- fix sensu-backend readinessProbe wget to conform to available busybox wget arguments
- adjust backend init job settings

Closes https://github.com/sensu/sensu-k8s-quick-start/issues/9